### PR TITLE
Fix target SDK config check (s/fromSdk/sdk/)

### DIFF
--- a/dsl/static/src/common/Internals.kt
+++ b/dsl/static/src/common/Internals.kt
@@ -250,7 +250,7 @@ object AnkoInternals {
         }
 
         if (sdk != null) {
-            if (Build.VERSION.SDK_INT != fromSdk) return false
+            if (Build.VERSION.SDK_INT != sdk) return false
         }
 
         if (uiMode != null) {


### PR DESCRIPTION
This is a patch to correct the use of the wrong parameter in `testConfiguration` when confirming the target Android SDK. 
